### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A Model Context Protocol (MCP) server that provides tools to fetch and interact with Hacker News content. This server enables AI assistants to access real-time Hacker News data including top stories, story details, comments, and search functionality.
 
+<a href="https://glama.ai/mcp/servers/@GeorgeNance/hackernews-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@GeorgeNance/hackernews-mcp/badge" alt="Hacker News Server MCP server" />
+</a>
+
 ## 🚀 Features
 
 ### 🛠️ Available Tools


### PR DESCRIPTION
This PR adds a badge for the [Hacker News MCP Server](https://glama.ai/mcp/servers/@GeorgeNance/hackernews-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@GeorgeNance/hackernews-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@GeorgeNance/hackernews-mcp/badge" alt="Hacker News Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.